### PR TITLE
Allow disabling Cert Validation for HTTPS connections

### DIFF
--- a/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
@@ -70,6 +70,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)  
 '''
@@ -183,6 +188,7 @@ def run_module():
         index=dict(type='str', required=False),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(

--- a/plugins/modules/unix_vmware_desktop_foldersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_foldersmgmt.py
@@ -70,6 +70,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)  
 '''
@@ -165,6 +170,7 @@ def run_module():
         access=dict(type='str', required=False),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(

--- a/plugins/modules/unix_vmware_desktop_netmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_netmgmt.py
@@ -104,6 +104,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)
 '''
@@ -232,6 +237,7 @@ def run_module():
         setting=dict(type='str', required=False, default=''),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(

--- a/plugins/modules/unix_vmware_desktop_power.py
+++ b/plugins/modules/unix_vmware_desktop_power.py
@@ -55,6 +55,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)
 '''
@@ -95,6 +100,7 @@ def run_module():
         state=dict(type='str', required=False, default=''),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(

--- a/plugins/modules/unix_vmware_desktop_vminfos.py
+++ b/plugins/modules/unix_vmware_desktop_vminfos.py
@@ -52,6 +52,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)
 '''
@@ -97,6 +102,7 @@ def run_module():
         target_vm_name=dict(type='str', required=False, default=''),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(

--- a/plugins/modules/unix_vmware_desktop_vmmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_vmmgmt.py
@@ -70,6 +70,11 @@ options:
         required: false
         default: "8697"
 
+    validate_certs: "no || yes"
+        description:
+            - Validate Certificate it HTTPS connection
+        required: false
+
 author:
     - Adam Magnier (@qsypoq)
 '''
@@ -136,6 +141,7 @@ def run_module():
         memory_mb=dict(type='int', required=False),
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
+        validate_certs=dict(type='bool', default='no'),
     )
 
     result = dict(


### PR DESCRIPTION
Tested with:
```
ansible 2.9.4
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.8 (default, Nov 21 2019, 19:31:34) [GCC 8.3.1 20190507 (Red Hat 8.3.1-4)]
```

```
- name: VMw WS API
  hosts: localhost
  gather_facts: no
  tasks:
    - name: "Get infos"
      unix_vmware_desktop_vminfos:
        api_url: "https://192.168.1.149"
        api_port: "8697"
        validate_certs: no
        username: "admin"
        password: "Passw0rd!1"
```