### PR TITLE
Change to use .encode() method for compatibility with Python 2.7.

### DIFF
--- a/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
@@ -205,7 +205,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
@@ -205,7 +205,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes.decode("utf-8"))
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
@@ -205,7 +205,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes).encode("utf-8")
+    request_creds = str(encodedBytes.decode("utf-8"))
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_foldersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_foldersmgmt.py
@@ -187,7 +187,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes.decode("utf-8"))
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_foldersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_foldersmgmt.py
@@ -187,7 +187,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_foldersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_foldersmgmt.py
@@ -187,7 +187,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes).encode("utf-8")
+    request_creds = str(encodedBytes.decode("utf-8"))
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_netmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_netmgmt.py
@@ -254,7 +254,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_power.py
+++ b/plugins/modules/unix_vmware_desktop_power.py
@@ -117,7 +117,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}

--- a/plugins/modules/unix_vmware_desktop_vminfos.py
+++ b/plugins/modules/unix_vmware_desktop_vminfos.py
@@ -119,7 +119,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {

--- a/plugins/modules/unix_vmware_desktop_vmmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_vmmgmt.py
@@ -142,7 +142,7 @@ def run_module():
     api_password = module.params['password']
     creds = api_username + ':' + api_password
     encodedBytes = base64.b64encode(creds.encode("utf-8"))
-    request_creds = str(encodedBytes, "utf-8")
+    request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
     headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}


### PR DESCRIPTION
This was used elsewhere, so it seemed like a straightforward enough change. This fix allowed the modules I've tested to work in my Python 2.7 environments.