### PR TITLE
When fetch_url() fails (req is None), use Ansible's fail_json() to return the information to the caller.

### DIFF
--- a/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_adaptersmgmt.py
@@ -265,7 +265,11 @@ def run_module():
 
     bodyjson = json.dumps(body)
 
-    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers, method=method)
+    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers,
+                          method=method)
+
+    if req is None:
+        module.fail_json(msg=info['msg'])
 
     if action == "delete":
         result['msg'] = info

--- a/plugins/modules/unix_vmware_desktop_foldersmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_foldersmgmt.py
@@ -247,7 +247,11 @@ def run_module():
 
     bodyjson = json.dumps(body)
 
-    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers, method=method)
+    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers,
+                          method=method)
+
+    if req is None:
+        module.fail_json(msg=info['msg'])
 
     if action == "delete":
         result['msg'] = info

--- a/plugins/modules/unix_vmware_desktop_netmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_netmgmt.py
@@ -302,7 +302,11 @@ def run_module():
 
     bodyjson = json.dumps(body)
 
-    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers, method=method)
+    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers,
+                          method=method)
+
+    if req is None:
+        module.fail_json(msg=info['msg'])
 
     if action == "delete":
         result['msg'] = info

--- a/plugins/modules/unix_vmware_desktop_vminfos.py
+++ b/plugins/modules/unix_vmware_desktop_vminfos.py
@@ -159,6 +159,9 @@ def run_module():
     method = "Get"
     req, info = fetch_url(module, request_url, headers=headers, method=method)
 
+    if req is None:
+        module.fail_json(msg=info['msg'])
+
     result['msg'] = json.loads(req.read())
     module.exit_json(**result)
 

--- a/plugins/modules/unix_vmware_desktop_vmmgmt.py
+++ b/plugins/modules/unix_vmware_desktop_vmmgmt.py
@@ -61,6 +61,12 @@ options:
         description:
             - Validate Certificate it HTTPS connection
         required: false
+    timeout: 
+        description:
+            - Specifies a timeout in seconds for communicating with vmrest
+        required: false
+        default: 30
+
 author:
     - Adam Magnier (@qsypoq)
 '''
@@ -126,6 +132,7 @@ def run_module():
         api_url=dict(type='str', default='http://127.0.0.1'),
         api_port=dict(type='str', default='8697'),
         validate_certs=dict(type='bool', default='no'),
+        timeout=dict(type='int', required=False, default=30)
     )
 
     result = dict(
@@ -145,7 +152,10 @@ def run_module():
     request_creds = str(encodedBytes).encode("utf-8")
     request_server = module.params['api_url']
     request_port = module.params['api_port']
-    headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json', 'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json', 'Authorization': 'Basic ' + request_creds}
+    headers = {'Accept': 'application/vnd.vmware.vmw.rest-v1+json',
+               'Content-Type': 'application/vnd.vmware.vmw.rest-v1+json',
+               'Authorization': 'Basic ' + request_creds}
+    timeout = module.params['timeout']
 
     target_vm = module.params['target_vm']
     action = module.params['action']
@@ -192,7 +202,13 @@ def run_module():
 
     bodyjson = json.dumps(body)
 
-    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers, method=method, timeout=60)
+    req, info = fetch_url(module, request_url, data=bodyjson, headers=headers,
+                          method=method, timeout=timeout)
+
+    if req is None:
+        module.fail_json(msg=info['msg'])
+
+    result["changed"] = True
 
     if action == "delete":
         result['msg'] = info


### PR DESCRIPTION
Before this change, some API calls which are expected to return non-2xx statuses from HTTP are actually normal responses and should not cause an error condition. (The underlying error was that req was None, and trying to dereference it a bit later would fail.)